### PR TITLE
v1.2.7 --stats or -s

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = validatortoolbox_fra
-version = 1.2.6
+version = 1.2.7
 author = EasyNode.PRO
 author_email = support@easynode.pro
 description = Findora FRA Validator Node Toolbox and Easy Setup

--- a/src/app.py
+++ b/src/app.py
@@ -24,7 +24,7 @@ from config import easy_env_fra
 
 def main() -> None:
     # Init parser for flags:
-    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser = argparse.ArgumentParser(description='Findora Validator Toolbox - Help Menu')
     parse_flags(parser)
     # Wear purple
     print(Fore.MAGENTA)

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ def getUrl() -> None:
 
 
 class easy_env_fra:
-    easy_version = "1.2.6"
+    easy_version = "1.2.7"
     server_host_name = socket.gethostname()
     user_home_dir = os.path.expanduser("~")
     dotenv_file = f"{user_home_dir}/.easynode.env"

--- a/src/library.py
+++ b/src/library.py
@@ -596,7 +596,6 @@ def menu_topper() -> None:
         input()
     subprocess.run("clear")
     print(Fore.MAGENTA)
-    print_stars()
     print(
         f"{Style.RESET_ALL}{Fore.MAGENTA}* {Fore.MAGENTA}validator-toolbox for Findora FRA Validators by Easy Node"
         + f"   v{easy_env_fra.easy_version}{Style.RESET_ALL}{Fore.MAGENTA}   https://easynode.pro *"
@@ -1116,7 +1115,7 @@ def run_findora_menu() -> None:
 
 def parse_flags(parser):
     # add the '--verbose' flag
-    parser.add_argument('--stats', action='store_true',
+    parser.add_argument('-s', '--stats', action='store_true',
                         help='Run your stats if Findora is installed and running.')
 
     parser.add_argument('--reset', action='store_true', help='This will wipe everything to allow you to reload Findora.')

--- a/src/library.py
+++ b/src/library.py
@@ -1128,7 +1128,7 @@ def parse_flags(parser):
     first_env_check(easy_env_fra.dotenv_file, easy_env_fra.user_home_dir)
 
     # check if the '--verbose' flag is set
-    if args.verbose:
+    if args.stats:
         menu_topper()
         finish_node()
     

--- a/src/library.py
+++ b/src/library.py
@@ -1116,8 +1116,8 @@ def run_findora_menu() -> None:
 
 def parse_flags(parser):
     # add the '--verbose' flag
-    parser.add_argument('--verbose', action='store_true',
-                        help='increase output verbosity')
+    parser.add_argument('--stats', action='store_true',
+                        help='Run your stats if Findora is installed and running.')
 
     parser.add_argument('--reset', action='store_true', help='This will wipe everything to allow you to reload Findora.')
 
@@ -1129,7 +1129,8 @@ def parse_flags(parser):
 
     # check if the '--verbose' flag is set
     if args.verbose:
-        print('Verbose mode enabled')
+        menu_topper()
+        finish_node()
     
     if args.reset:
         print_stars()

--- a/src/library.py
+++ b/src/library.py
@@ -1132,7 +1132,7 @@ def parse_flags(parser):
     
     if args.reset:
         print_stars()
-        answer = ask_yes_no(f"* You've started the reset process. Press enter to wipe your system or ctrl+c to exit.")
+        answer = ask_yes_no(f"* You've started the reset process. Press Y to reset or N ot exit: (Y/N) ")
         if answer:
             # wipe data here
             shutil.rmtree(f'{easy_env_fra.findora_root}/{environ.get("FRA_NETWORK")}')

--- a/src/library.py
+++ b/src/library.py
@@ -595,7 +595,6 @@ def menu_topper() -> None:
         print_stars()
         input()
     subprocess.run("clear")
-    print(Fore.MAGENTA)
     print(
         f"{Style.RESET_ALL}{Fore.MAGENTA}* {Fore.MAGENTA}validator-toolbox for Findora FRA Validators by Easy Node"
         + f"   v{easy_env_fra.easy_version}{Style.RESET_ALL}{Fore.MAGENTA}   https://easynode.pro *"

--- a/src/library.py
+++ b/src/library.py
@@ -478,9 +478,6 @@ def capture_stats() -> None:
     try:
         response = requests.get("http://localhost:26657/status")
         stats = json.loads(response.text)
-        # data = json.dumps(output, ensure_ascii=False, indent=4)
-        # status_code = int(output[1])
-        print_stars()
         return stats
     except:
         print("* No response from the rpc.\n* Is Docker running?")
@@ -595,6 +592,8 @@ def menu_topper() -> None:
         print_stars()
         input()
     subprocess.run("clear")
+    print(Fore.MAGENTA)
+    print_stars()
     print(
         f"{Style.RESET_ALL}{Fore.MAGENTA}* {Fore.MAGENTA}validator-toolbox for Findora FRA Validators by Easy Node"
         + f"   v{easy_env_fra.easy_version}{Style.RESET_ALL}{Fore.MAGENTA}   https://easynode.pro *"


### PR DESCRIPTION
Good to go with the stats!

-s or --stats after app.py will simply run stats. To run them anywhere without launching, after upgrading to this version of course, run:

`python3 ~/validatortoolbox_fra/src/app.py -s`